### PR TITLE
Update cmark-gfm-swift.podspec

### DIFF
--- a/cmark-gfm-swift.podspec
+++ b/cmark-gfm-swift.podspec
@@ -19,10 +19,10 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
 
-  s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h'
+  s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h', 'Source/**/*.inc'
   s.public_header_files = 'Source/*.h'
   s.exclude_files = "Source/Info.plist"
-  s.preserve_path = 'Source/cmark_gfm/module.modulemap'
+  s.preserve_paths = 'Source/cmark_gfm/module.modulemap', 'Source/cmark_gfm/scanners.re'
   s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/cmark-gfm-swift/Source/cmark_gfm/**' }
 
 end

--- a/cmark-gfm-swift.podspec
+++ b/cmark-gfm-swift.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
 
-  s.source_files = 'Source/**/*'
+  s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h'
   s.public_header_files = 'Source/*.h'
   s.exclude_files = "Source/Info.plist"
   s.preserve_path = 'cmark-gfm-swift/Source/cmark_gfm/module.modulemap'

--- a/cmark-gfm-swift.podspec
+++ b/cmark-gfm-swift.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h'
   s.public_header_files = 'Source/*.h'
   s.exclude_files = "Source/Info.plist"
+  s.header_mappings_dir = 'Source/cmark_gfm'
   s.preserve_path = 'cmark-gfm-swift/Source/cmark_gfm/module.modulemap'
   s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/cmark-gfm-swift/Source/cmark_gfm/**' }
 

--- a/cmark-gfm-swift.podspec
+++ b/cmark-gfm-swift.podspec
@@ -22,8 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h'
   s.public_header_files = 'Source/*.h'
   s.exclude_files = "Source/Info.plist"
-  s.header_mappings_dir = 'Source/cmark_gfm'
-  s.preserve_path = 'cmark-gfm-swift/Source/cmark_gfm/module.modulemap'
+  s.preserve_path = 'Source/cmark_gfm/module.modulemap'
   s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/cmark-gfm-swift/Source/cmark_gfm/**' }
 
 end


### PR DESCRIPTION
Includes only compilable files in the `source_files` property, that way we get rid of the annoying warnings.

![Screenshot 2019-06-21 at 17 42 32](https://user-images.githubusercontent.com/39093828/59938244-5e2ddc80-944c-11e9-958d-26cfb0bbb5c0.png)
